### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -8,3 +8,4 @@ category=Device Control
 url=https://github.com/m5stack/M5Atom
 architectures=esp32
 includes=M5Atom.h
+depends=FastLED


### PR DESCRIPTION
Specifying the library dependencies in the depends field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library. "arduino-cli lib install" will automatically install the dependencies (arduino-cli 0.7.0 and newer).